### PR TITLE
Remove namespace button when viewing stream entries

### DIFF
--- a/src/StreamsModule.php
+++ b/src/StreamsModule.php
@@ -61,13 +61,6 @@ class StreamsModule extends Module
                 'new_entry'        => [
                     'href' => 'admin/streams/entries/{request.route.parameters.stream}/create',
                 ],
-                'change_namespace' => [
-                    'type'        => 'info',
-                    'data-toggle' => 'modal',
-                    'data-target' => '#modal',
-                    'icon'        => 'fa fa-random',
-                    'href'        => 'admin/streams/namespaces/change?entries=true',
-                ],
             ],
         ],
         'fields'     => [


### PR DESCRIPTION
I don't think this button belongs in this context.  By the time you've clicked on a specific stream the buttons should all be related to that stream.  I think the namespace button make sense at the top level, just not at an entries level.